### PR TITLE
청소 요청 상세 페이지 ui 개발

### DIFF
--- a/src/app/_components/molecules/SidebarItem.tsx
+++ b/src/app/_components/molecules/SidebarItem.tsx
@@ -11,7 +11,7 @@ interface SidebarItemProps {
 
 export default function SidebarItem({ label, href }: SidebarItemProps) {
   const pathname = usePathname();
-  const isActive = pathname === href;
+  const isActive = pathname === href || pathname.startsWith(`${href}/`);
 
   return (
     <Link href={href}>

--- a/src/app/_components/molecules/card/CleaningRequestCard.tsx
+++ b/src/app/_components/molecules/card/CleaningRequestCard.tsx
@@ -12,7 +12,7 @@ interface CleaningRequestCardProps {
   requestDateTime: string;
   completionDateTime: string;
   selectedOption: string;
-  status: 'pending' | 'scheduled' | 'in-progress' | 'completed' | 'canceled';
+  requestStatus: 'pending' | 'scheduled' | 'in-progress' | 'completed' | 'canceled';
   cleaningStartDateTime?: string;
   onCheckCleaner?: () => void;
   onClickDetail?: () => void;
@@ -36,7 +36,7 @@ export default function CleaningRequestCard({
   requestDateTime,
   completionDateTime,
   selectedOption,
-  status,
+  requestStatus,
   cleaningStartDateTime,
   onCheckCleaner,
   onClickDetail,
@@ -45,7 +45,7 @@ export default function CleaningRequestCard({
   onWriteReview,
 }: CleaningRequestCardProps) {
   const getStatusLabel = () => {
-    const config = getStatusLabelConfig(status, isPastRequest);
+    const config = getStatusLabelConfig(requestStatus, isPastRequest);
     if (!config) return null;
 
     return (
@@ -86,7 +86,7 @@ export default function CleaningRequestCard({
                 getStatusLabel()
               ) : (
                 <Link
-                  href={`/mypage/request/detail/${id}`}
+                  href={`/mypage/request/detail/${id}?requestStatus=${requestStatus}`}
                   onClick={onClickDetail}
                   className="w-[70px] whitespace-nowrap text-neutral-500 hover:text-neutral-800 flex items-center flex-shrink-0"
                 >
@@ -104,7 +104,8 @@ export default function CleaningRequestCard({
                       <BodySmall className="text-neutral-600">요청 일시: </BodySmall>
                       <BodySmall className="text-neutral-800 ml-1">{requestDateTime}</BodySmall>
                     </div>
-                    {(status === 'in-progress' || (isPastRequest && status === 'completed')) &&
+                    {(requestStatus === 'in-progress' ||
+                      (isPastRequest && requestStatus === 'completed')) &&
                       cleaningStartDateTime && (
                         <div className="flex">
                           <BodySmall className="text-neutral-600">청소 시작 시각: </BodySmall>
@@ -125,7 +126,7 @@ export default function CleaningRequestCard({
                     </div>
                   </div>
                 </div>
-                {status === 'pending' && !isPastRequest && (
+                {requestStatus === 'pending' && !isPastRequest && (
                   <div className="w-full md:w-[200px] lg:w-full min-[1363px]:w-[200px] self-end">
                     <Link href={`/mypage/request/cleaner-list/${id}`}>
                       <Button onClick={onCheckCleaner} active className="h-[46px] w-full">
@@ -134,7 +135,7 @@ export default function CleaningRequestCard({
                     </Link>
                   </div>
                 )}
-                {isPastRequest && status === 'completed' && (
+                {isPastRequest && requestStatus === 'completed' && (
                   <div className="w-full md:w-[200px] lg:w-full min-[1363px]:w-[200px] self-end">
                     <Button onClick={onWriteReview} active className="h-[46px] w-full">
                       리뷰 작성하기

--- a/src/app/_components/organisms/CleaningRequestListSection.tsx
+++ b/src/app/_components/organisms/CleaningRequestListSection.tsx
@@ -41,7 +41,7 @@ export interface CleaningRequest {
   requestDateTime: string;
   completionDateTime: string;
   selectedOption: string;
-  status: 'pending' | 'scheduled' | 'in-progress' | 'completed' | 'canceled';
+  requestStatus: 'pending' | 'scheduled' | 'in-progress' | 'completed' | 'canceled';
   cleaningStartDateTime?: string;
 }
 
@@ -172,7 +172,7 @@ export default function CleaningRequestListSection({ data }: CleaningRequestList
               requestDateTime={request.requestDateTime}
               completionDateTime={request.completionDateTime}
               selectedOption={request.selectedOption}
-              status={request.status}
+              requestStatus={request.requestStatus}
               cleaningStartDateTime={request.cleaningStartDateTime}
               showStatusLabel={mainTab === 'ongoing' && subTab === 'all'}
               isPastRequest={mainTab === 'past'}

--- a/src/app/_components/organisms/RequestDetailSection.tsx
+++ b/src/app/_components/organisms/RequestDetailSection.tsx
@@ -1,0 +1,260 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import Button from '../atoms/Button';
+import {
+  DisplayH3,
+  DisplayH4,
+  BodySmall,
+  BodyDefault,
+  TitleH4,
+  TitleDefault,
+} from '../atoms/Typography';
+
+interface RequestDetailSectionProps {
+  // 헤더 정보
+  imageUrl: string;
+  title: string;
+  requestDateTime: string;
+  cleaningStartDateTime?: string;
+  completionDateTime: string;
+  selectedOption: string;
+  requestStatus: 'pending' | 'scheduled' | 'in-progress';
+  requestId: string;
+  // 청소 기본 규칙
+  triggerPoint: string;
+  requestPeriod: string;
+  phoneNumber: string;
+  emergencyContact: string;
+  // 청소자 조건 필터
+  minimumRating: number;
+  minimumExperience: string;
+  // 텍스트 메모
+  memo: string;
+  // 참고 사진
+  referencePhotos: string[];
+  // 결제 정보
+  baseFee: number;
+  platformFee: number;
+  platformFeeRate: number;
+  // 이벤트 핸들러
+  onCheckCleaner?: () => void;
+  onCancelRequest?: () => void;
+}
+
+/**
+ * 요청 상세 정보 섹션 컴포넌트
+ *
+ * 상태에 따라 다른 정보를 표시
+ * - pending, scheduled: 요청 취소하기 버튼 표시
+ * - in-progress: 요청 취소하기 버튼 미표시
+ */
+export default function RequestDetailSection({
+  imageUrl,
+  title,
+  requestDateTime,
+  cleaningStartDateTime,
+  completionDateTime,
+  selectedOption,
+  requestStatus,
+  requestId,
+  triggerPoint,
+  requestPeriod,
+  phoneNumber,
+  emergencyContact,
+  minimumRating,
+  minimumExperience,
+  memo,
+  referencePhotos,
+  baseFee,
+  platformFee,
+  platformFeeRate,
+  onCheckCleaner,
+  onCancelRequest,
+}: RequestDetailSectionProps) {
+  const showCancelButton = requestStatus === 'pending' || requestStatus === 'scheduled';
+
+  const getStatusTitle = () => {
+    switch (requestStatus) {
+      case 'pending':
+        return '요청 상세 정보';
+      case 'scheduled':
+        return '청소 진행 예정 상세 정보';
+      case 'in-progress':
+        return '청소 진행 중 상세 정보';
+      default:
+        return '요청 상세 정보';
+    }
+  };
+
+  return (
+    <div>
+      <DisplayH3 className="text-neutral-1000 mb-[25px]">{getStatusTitle()}</DisplayH3>
+      <div className="rounded-[16px] bg-neutral-100 py-8 px-6 box-sizing: border-box border border-neutral-200 shadow-[0_3px_10px_0_rgba(0_0_0/0.2)] overflow-visible">
+        {/* 헤더 */}
+        <div className="flex flex-col gap-8">
+          <div className="space-y-6">
+            <div className="flex flex-col md:flex-row gap-6">
+              <div className="w-[219px] h-[219px] md:w-[112px] md:h-[112px] rounded-[16px] overflow-hidden bg-neutral-200 flex-shrink-0 self-center md:self-auto">
+                <Image
+                  src={imageUrl}
+                  alt={title}
+                  width={219}
+                  height={219}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+
+              <div className="flex-1 w-full">
+                <DisplayH4 className="text-neutral-1000">{title}</DisplayH4>
+                <div className="mt-4 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="flex flex-col gap-1">
+                    <div className="flex">
+                      <BodySmall className="text-neutral-600">요청 일시: </BodySmall>
+                      <BodySmall className="text-neutral-800 ml-1">{requestDateTime}</BodySmall>
+                    </div>
+                    {requestStatus === 'in-progress' && cleaningStartDateTime && (
+                      <div className="flex">
+                        <BodySmall className="text-neutral-600">청소 시작 시각: </BodySmall>
+                        <BodySmall className="text-neutral-800 ml-1">
+                          {cleaningStartDateTime}
+                        </BodySmall>
+                      </div>
+                    )}
+                    <div className="flex">
+                      <BodySmall className="text-neutral-600">
+                        청소 완료 날짜 및 희망 시각:{' '}
+                      </BodySmall>
+                      <BodySmall className="text-neutral-800 ml-1">{completionDateTime}</BodySmall>
+                    </div>
+                    <div className="flex">
+                      <BodySmall className="text-neutral-600">선택 옵션: </BodySmall>
+                      <BodySmall className="text-neutral-800 ml-1">{selectedOption}</BodySmall>
+                    </div>
+                  </div>
+                  <div className="w-full md:w-[200px] self-end">
+                    <Link
+                      href={
+                        requestStatus === 'pending'
+                          ? `/mypage/request/cleaner-list/${requestId}`
+                          : `/mypage/request/cleaner-list/${requestId}`
+                      }
+                    >
+                      <Button onClick={onCheckCleaner} active className="h-[46px] w-full">
+                        {requestStatus === 'pending'
+                          ? '청소자 요청 목록 확인'
+                          : '청소자 상세 정보 확인'}
+                      </Button>
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          {/* 청소 기본 규칙 */}
+          <div className="flex flex-col gap-10">
+            <div className="space-y-4">
+              <TitleH4 className="text-neutral-1000">청소 기본 규칙</TitleH4>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <BodyDefault className="text-neutral-800">청소 요청 트리거 시점</BodyDefault>
+                  <TitleDefault className="text-neutral-1000">{triggerPoint}</TitleDefault>
+                </div>
+                <div className="flex items-center justify-between">
+                  <BodyDefault className="text-neutral-800">요청 기간</BodyDefault>
+                  <TitleDefault className="text-neutral-1000">{requestPeriod}</TitleDefault>
+                </div>
+                <div className="flex items-center justify-between">
+                  <BodyDefault className="text-neutral-800">전화번호</BodyDefault>
+                  <TitleDefault className="text-neutral-1000">{phoneNumber}</TitleDefault>
+                </div>
+                <div className="flex items-center justify-between">
+                  <BodyDefault className="text-neutral-800">비상 연락처</BodyDefault>
+                  <TitleDefault className="text-neutral-1000">{emergencyContact}</TitleDefault>
+                </div>
+              </div>
+            </div>
+            {/* 청소자 조건 필터 */}
+            <div className="space-y-4">
+              <TitleH4 className="text-neutral-1000">청소자 조건 필터</TitleH4>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <BodyDefault className="text-neutral-800">최소 평점</BodyDefault>
+                  <TitleDefault className="text-neutral-1000">{minimumRating}/5.0</TitleDefault>
+                </div>
+                <div className="flex items-center justify-between">
+                  <BodyDefault className="text-neutral-800">최소 경력</BodyDefault>
+                  <TitleDefault className="text-neutral-1000">{minimumExperience}</TitleDefault>
+                </div>
+              </div>
+            </div>
+            {/* 텍스트 메모 */}
+            <div className="space-y-4">
+              <TitleH4 className="text-neutral-1000">텍스트 메모</TitleH4>
+              <TitleDefault className="text-neutral-800 whitespace-pre-wrap">{memo}</TitleDefault>
+            </div>
+            {/* 참고 사진 */}
+            {referencePhotos && referencePhotos.length > 0 && (
+              <div className="space-y-4">
+                <TitleH4 className="text-neutral-1000">참고 사진</TitleH4>
+                <div className="flex gap-4 overflow-x-auto scrollbar-hide">
+                  {referencePhotos.map((photo, index) => (
+                    <div
+                      key={index}
+                      className="flex-shrink-0 w-[112px] h-[112px] rounded-[20px] overflow-hidden bg-neutral-200"
+                    >
+                      <Image
+                        src={photo}
+                        alt={`참고 사진 ${index + 1}`}
+                        width={112}
+                        height={112}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {/* 결제 예상 금액 */}
+            <div className="space-y-4">
+              <TitleH4 className="text-neutral-1000">결제 예상 금액</TitleH4>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <BodyDefault className="text-neutral-600">기본 요금</BodyDefault>
+                  <TitleDefault className="text-neutral-800">
+                    {new Intl.NumberFormat('ko-KR').format(baseFee)} 원
+                  </TitleDefault>
+                </div>
+                <div className="flex justify-between items-center">
+                  <BodyDefault className="text-neutral-600">
+                    플랫폼 수수료 ({platformFeeRate}%)
+                  </BodyDefault>
+                  <TitleDefault className="text-neutral-800">
+                    {new Intl.NumberFormat('ko-KR').format(platformFee)} 원
+                  </TitleDefault>
+                </div>
+                <div className="border-t border-neutral-300 pt-2">
+                  <div className="flex justify-between items-center">
+                    <BodyDefault className="text-neutral-1000">결제 예정 금액</BodyDefault>
+                    <TitleH4 className="text-neutral-1000">
+                      {new Intl.NumberFormat('ko-KR').format(baseFee + platformFee)}원
+                    </TitleH4>
+                  </div>
+                </div>
+              </div>
+            </div>
+            {/* 요청 취소하기 버튼 */}
+            {showCancelButton && (
+              <div className="pt-4 md:flex md:justify-end">
+                <div className="w-full md:w-[151px]">
+                  <Button onClick={onCancelRequest} variant="secondary" className="h-[46px] w-full">
+                    요청 취소하기
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/templates/RoomMainTemplate.tsx
+++ b/src/app/_components/templates/RoomMainTemplate.tsx
@@ -7,7 +7,7 @@ interface RoomMainTemplateProps {
 
 export default function RoomMainTemplate({ children, showSidebar = true }: RoomMainTemplateProps) {
   return (
-    <div className="mx-auto w-full px-4 md:px-6 lg:px-[36px] py-8 md:py-[60px] lg:py-20">
+    <div className="mx-auto w-full px-4 md:px-6 lg:px-[36px] py-10">
       {showSidebar ? (
         <div className="flex gap-12">
           <Sidebar />

--- a/src/app/mypage/request/detail/[id]/page.tsx
+++ b/src/app/mypage/request/detail/[id]/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import RoomMainTemplate from '@/app/_components/templates/RoomMainTemplate';
+import RequestDetailSection from '@/app/_components/organisms/RequestDetailSection';
+
+/**
+ * 요청 상세 페이지
+ *
+ * 상태에 따라 다른 정보를 표시합니다.
+ * - pending: 요청 대기 중
+ * - scheduled: 청소 진행 예정
+ * - in-progress: 청소 진행 중
+ */
+export default function RequestDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const id = params?.id as string;
+  const statusParam = (searchParams.get('requestStatus') || 'pending') as
+    | 'pending'
+    | 'scheduled'
+    | 'in-progress';
+
+  const mockRequestData = {
+    id: id || '1',
+    imageUrl: '/img/sample-room.jpg',
+    title: '외대 앞 에어비앤비 자동 청소',
+    requestDateTime: '2025/10/31 18:29',
+    cleaningStartDateTime: '2025/10/31 18:29', // in-progress일 때만 표시
+    completionDateTime: '2025/11/3 18:00',
+    selectedOption: '청소만(기본 옵션)',
+    requestStatus: statusParam as 'pending' | 'scheduled' | 'in-progress',
+    triggerPoint: '체크아웃 즉시',
+    requestPeriod: '2025/11/1 ~ 2025/12/1',
+    phoneNumber: '010-0000-0000',
+    emergencyContact: '010-0000-0000',
+    minimumRating: 4.0,
+    minimumExperience: '3개월 이상',
+    memo: `외대 앞 에어비앤비입니다. 학생들이 많이 사용하므로 청결한 분위기를 유지해야 합니다. 현관부터 전체적으로 청소해주시면 됩니다. 정확한 주소는 다음과 같으며, 잘 부탁드립니다.`,
+    referencePhotos: [
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+    ],
+    baseFee: 50000,
+    platformFee: 7500,
+    platformFeeRate: 15,
+  };
+
+  // const { data, isLoading, error } = useRequestDetail(id);
+
+  const handleCheckCleaner = () => {
+    console.log('청소자 정보 확인:', id);
+  };
+
+  const handleCancelRequest = () => {
+    console.log('요청 취소:', id);
+    // 취소 성공 시 목록 페이지로 이동
+    router.push('/mypage/request');
+  };
+
+  return (
+    <RoomMainTemplate>
+      <RequestDetailSection
+        imageUrl={mockRequestData.imageUrl}
+        title={mockRequestData.title}
+        requestDateTime={mockRequestData.requestDateTime}
+        cleaningStartDateTime={
+          mockRequestData.requestStatus === 'in-progress'
+            ? mockRequestData.cleaningStartDateTime
+            : undefined
+        }
+        completionDateTime={mockRequestData.completionDateTime}
+        selectedOption={mockRequestData.selectedOption}
+        requestStatus={mockRequestData.requestStatus}
+        requestId={mockRequestData.id}
+        triggerPoint={mockRequestData.triggerPoint}
+        requestPeriod={mockRequestData.requestPeriod}
+        phoneNumber={mockRequestData.phoneNumber}
+        emergencyContact={mockRequestData.emergencyContact}
+        minimumRating={mockRequestData.minimumRating}
+        minimumExperience={mockRequestData.minimumExperience}
+        memo={mockRequestData.memo}
+        referencePhotos={mockRequestData.referencePhotos}
+        baseFee={mockRequestData.baseFee}
+        platformFee={mockRequestData.platformFee}
+        platformFeeRate={mockRequestData.platformFeeRate}
+        onCheckCleaner={handleCheckCleaner}
+        onCancelRequest={handleCancelRequest}
+      />
+    </RoomMainTemplate>
+  );
+}

--- a/src/app/mypage/request/page.tsx
+++ b/src/app/mypage/request/page.tsx
@@ -25,7 +25,7 @@ export default function CleaningRequestManagePage() {
           requestDateTime: '2025/10/31 18:29',
           completionDateTime: '2025/11/3 18:00',
           selectedOption: '청소만(기본 옵션)',
-          status: 'pending',
+          requestStatus: 'pending',
         },
         {
           id: '2',
@@ -34,7 +34,7 @@ export default function CleaningRequestManagePage() {
           requestDateTime: '2025/10/31 20:15',
           completionDateTime: '2025/11/4 14:00',
           selectedOption: '청소만(기본 옵션)',
-          status: 'pending',
+          requestStatus: 'pending',
         },
       ],
       scheduled: [
@@ -45,7 +45,7 @@ export default function CleaningRequestManagePage() {
           requestDateTime: '2025/11/1 09:30',
           completionDateTime: '2025/11/5 10:00',
           selectedOption: '청소 + 빨래(추가 옵션)',
-          status: 'scheduled',
+          requestStatus: 'scheduled',
         },
         {
           id: '4',
@@ -54,7 +54,7 @@ export default function CleaningRequestManagePage() {
           requestDateTime: '2025/11/1 14:20',
           completionDateTime: '2025/11/6 09:00',
           selectedOption: '청소만(기본 옵션)',
-          status: 'scheduled',
+          requestStatus: 'scheduled',
         },
       ],
       'in-progress': [
@@ -66,7 +66,7 @@ export default function CleaningRequestManagePage() {
           cleaningStartDateTime: '2025/11/3 13:29',
           completionDateTime: '2025/11/2 16:00',
           selectedOption: '청소 + 정리정돈(추가 옵션)',
-          status: 'in-progress',
+          requestStatus: 'in-progress',
         },
       ],
     },
@@ -80,7 +80,7 @@ export default function CleaningRequestManagePage() {
           cleaningStartDateTime: '2025/11/3 13:29',
           completionDateTime: '2025/11/3 18:00',
           selectedOption: '청소만(기본 옵션)',
-          status: 'completed',
+          requestStatus: 'completed',
         },
         {
           id: '7',
@@ -90,7 +90,7 @@ export default function CleaningRequestManagePage() {
           cleaningStartDateTime: '2025/11/3 13:29',
           completionDateTime: '2025/11/3 18:00',
           selectedOption: '청소만(기본 옵션)',
-          status: 'canceled',
+          requestStatus: 'canceled',
         },
       ],
       completed: [
@@ -102,7 +102,7 @@ export default function CleaningRequestManagePage() {
           cleaningStartDateTime: '2025/11/3 13:29',
           completionDateTime: '2025/11/3 18:00',
           selectedOption: '청소만(기본 옵션)',
-          status: 'completed',
+          requestStatus: 'completed',
         },
       ],
       canceled: [
@@ -114,7 +114,7 @@ export default function CleaningRequestManagePage() {
           cleaningStartDateTime: '2025/11/3 13:29',
           completionDateTime: '2025/11/3 18:00',
           selectedOption: '청소만(기본 옵션)',
-          status: 'canceled',
+          requestStatus: 'canceled',
         },
       ],
     },

--- a/src/utils/cleaningRequest.utils.ts
+++ b/src/utils/cleaningRequest.utils.ts
@@ -10,12 +10,12 @@ export interface StatusLabelConfig {
 
 /**
  * 청소 요청 상태에 따른 라벨 설정을 반환하는 함수
- * @param status - 청소 요청 상태
+ * @param requestStatus - 청소 요청 상태
  * @param isPastRequest - 과거 요청 여부
  * @returns 상태 라벨 설정 객체 또는 null
  */
 export const getStatusLabelConfig = (
-  status: CleaningRequestStatus,
+  requestStatus: CleaningRequestStatus,
   isPastRequest: boolean,
 ): StatusLabelConfig | null => {
   if (isPastRequest) {
@@ -32,7 +32,7 @@ export const getStatusLabelConfig = (
       },
     };
 
-    return pastStatusConfig[status as PastStatus] || null;
+    return pastStatusConfig[requestStatus as PastStatus] || null;
   }
 
   const ongoingStatusConfig: Record<OngoingStatus, StatusLabelConfig> = {
@@ -53,6 +53,5 @@ export const getStatusLabelConfig = (
     },
   };
 
-  return ongoingStatusConfig[status as OngoingStatus] || null;
+  return ongoingStatusConfig[requestStatus as OngoingStatus] || null;
 };
-


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #38

## 📝 작업 내용
> 청소 요청 상세 페이지 ui 개발

- 진행 상태별(대기중 `pending` / 진행 예정 `scheduled` / 진행 중 `in-progress`) 상세 페이지를 `RequestDetailSection`에서 `requestStatus` 값으로 분기 렌더링하도록 구현
- 목록 페이지의 카드에서 상태를 쿼리로 전달

### 📸 스크린샷 (선택)
- 요청 대기 중
<img width="600" height="3092" alt="localhost_3000_mypage_request_detail_1 (1)" src="https://github.com/user-attachments/assets/0c6cbcb8-107f-4aef-b4c4-ecd1100ba36a" />

- 요청 진행 예정
<img width="600" height="3092" alt="localhost_3000_mypage_request_detail_4_status=scheduled" src="https://github.com/user-attachments/assets/1a1f337d-9e17-4b80-b06f-3a59d1bdb8a7" />

- 요청 진행 중
<img width="600" height="2932" alt="localhost_3000_mypage_request_detail_1 (2)" src="https://github.com/user-attachments/assets/37b101a8-3b8a-463a-9cc2-4d4194c29fab" />




