### PR TITLE
청소 상태 검수 ui 구현

### DIFF
--- a/src/app/_components/organisms/InspectionDetailSection.tsx
+++ b/src/app/_components/organisms/InspectionDetailSection.tsx
@@ -66,11 +66,6 @@ export default function InspectionDetailSection({
       {/* 헤더 */}
       <div className="mb-6">
         <DisplayH3 className="text-neutral-1000 mb-2">청소 상태 검수</DisplayH3>
-        <div className="flex items-center">
-          <TitleSmall className="text-neutral-600">청소 완료 후 </TitleSmall>
-          <TitleSmall className="text-red-200 ml-1">{elapsedTime}</TitleSmall>
-          <TitleSmall className="text-neutral-600 ml-1">경과</TitleSmall>
-        </div>
       </div>
 
       <div className="rounded-[16px] bg-neutral-100 py-8 px-6 box-sizing: border-box border border-neutral-200 shadow-[0_3px_10px_0_rgba(0_0_0/0.2)] overflow-visible">
@@ -78,19 +73,25 @@ export default function InspectionDetailSection({
           {/* 청소 요청 상세 정보 */}
           <div className="space-y-6">
             <div className="flex flex-col md:flex-row gap-6">
-              <div className="w-[219px] h-[219px] md:w-[112px] md:h-[112px] rounded-[16px] overflow-hidden bg-neutral-200 flex-shrink-0 self-center md:self-auto">
+              <div className="w-[136px] h-[136px] rounded-[16px] overflow-hidden bg-neutral-200 flex-shrink-0 self-center md:self-auto">
                 <Image
                   src={accommodationImageUrl}
                   alt={accommodationName}
-                  width={219}
-                  height={219}
+                  width={136}
+                  height={136}
                   className="w-full h-full object-cover"
                 />
               </div>
-
-              <div className="flex-1 w-full">
-                <DisplayH4 className="text-neutral-1000">{accommodationName}</DisplayH4>
-                <div className="mt-4 flex flex-col gap-1">
+              <div className="flex-1 w-full flex flex-col">
+                <div className="flex items-center justify-between mb-4">
+                  <DisplayH4 className="text-neutral-1000">{accommodationName}</DisplayH4>
+                  <div className="flex items-center flex-shrink-0">
+                    <TitleSmall className="text-neutral-600">청소 완료 후 </TitleSmall>
+                    <TitleSmall className="text-red-200 ml-1">{elapsedTime}</TitleSmall>
+                    <TitleSmall className="text-neutral-600 ml-1">경과</TitleSmall>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-1">
                   <div className="flex">
                     <BodySmall className="text-neutral-600">요청 일시: </BodySmall>
                     <BodySmall className="text-neutral-800 ml-1">
@@ -245,13 +246,13 @@ export default function InspectionDetailSection({
           {/* 액션 버튼 */}
           <div className="pt-4 flex flex-col md:flex-row gap-4 md:justify-end">
             <div className="w-full md:w-[151px]">
-              <Button onClick={onRequestRework} variant="secondary" className="h-[46px] w-full">
-                재작업 요청하기
+              <Button onClick={onApprove} active className="h-[46px] w-full">
+                승인하기
               </Button>
             </div>
             <div className="w-full md:w-[151px]">
-              <Button onClick={onApprove} active className="h-[46px] w-full">
-                승인하기
+              <Button onClick={onRequestRework} variant="secondary" className="h-[46px] w-full">
+                재작업 요청하기
               </Button>
             </div>
           </div>

--- a/src/app/_components/organisms/InspectionDetailSection.tsx
+++ b/src/app/_components/organisms/InspectionDetailSection.tsx
@@ -83,9 +83,9 @@ export default function InspectionDetailSection({
                 />
               </div>
               <div className="flex-1 w-full flex flex-col">
-                <div className="flex items-center justify-between mb-4">
+                <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-2 lg:gap-0 mb-4">
                   <DisplayH4 className="text-neutral-1000">{accommodationName}</DisplayH4>
-                  <div className="flex items-center flex-shrink-0">
+                  <div className="flex items-center flex-shrink-0 lg:ml-auto">
                     <TitleSmall className="text-neutral-600">청소 완료 후 </TitleSmall>
                     <TitleSmall className="text-red-200 ml-1">{elapsedTime}</TitleSmall>
                     <TitleSmall className="text-neutral-600 ml-1">경과</TitleSmall>

--- a/src/app/_components/organisms/InspectionDetailSection.tsx
+++ b/src/app/_components/organisms/InspectionDetailSection.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import Image from 'next/image';
+import Button from '../atoms/Button';
+import {
+  DisplayH3,
+  DisplayH4,
+  BodySmall,
+  BodyDefault,
+  TitleH4,
+  TitleDefault,
+  TitleSmall,
+} from '../atoms/Typography';
+import { formatDateTime } from '@/utils/dateTime.utils';
+
+interface InspectionDetailSectionProps {
+  // 헤더 정보
+  accommodationName: string;
+  accommodationImageUrl: string;
+  elapsedTime: string; // 예: "8시간 30분"
+  // 청소 요청 정보
+  requestedDatetime: string;
+  cleaningStartDateTime: string;
+  completedAt: string;
+  selectedOption: string;
+  // 사진
+  beforeCleaningPhotos: string[];
+  afterCleaningPhotos: string[];
+  // 특이사항
+  specialNotes?: string;
+  specialNotesPhotos?: string[];
+  // 결제 정보
+  baseFee: number;
+  platformFee: number;
+  platformFeeRate: number;
+  // 이벤트 핸들러
+  onApprove?: () => void;
+  onRequestRework?: () => void;
+}
+
+/**
+ * 청소 상태 검수 상세 섹션 컴포넌트
+ *
+ * 청소 완료 후 검수하는 페이지에서 사용
+ */
+export default function InspectionDetailSection({
+  accommodationName,
+  accommodationImageUrl,
+  elapsedTime,
+  requestedDatetime,
+  cleaningStartDateTime,
+  completedAt,
+  selectedOption,
+  beforeCleaningPhotos,
+  afterCleaningPhotos,
+  specialNotes,
+  specialNotesPhotos,
+  baseFee,
+  platformFee,
+  platformFeeRate,
+  onApprove,
+  onRequestRework,
+}: InspectionDetailSectionProps) {
+  return (
+    <div>
+      {/* 헤더 */}
+      <div className="mb-6">
+        <DisplayH3 className="text-neutral-1000 mb-2">청소 상태 검수</DisplayH3>
+        <div className="flex items-center">
+          <TitleSmall className="text-neutral-600">청소 완료 후 </TitleSmall>
+          <TitleSmall className="text-red-200 ml-1">{elapsedTime}</TitleSmall>
+          <TitleSmall className="text-neutral-600 ml-1">경과</TitleSmall>
+        </div>
+      </div>
+
+      <div className="rounded-[16px] bg-neutral-100 py-8 px-6 box-sizing: border-box border border-neutral-200 shadow-[0_3px_10px_0_rgba(0_0_0/0.2)] overflow-visible">
+        <div className="flex flex-col gap-8">
+          {/* 청소 요청 상세 정보 */}
+          <div className="space-y-6">
+            <div className="flex flex-col md:flex-row gap-6">
+              <div className="w-[219px] h-[219px] md:w-[112px] md:h-[112px] rounded-[16px] overflow-hidden bg-neutral-200 flex-shrink-0 self-center md:self-auto">
+                <Image
+                  src={accommodationImageUrl}
+                  alt={accommodationName}
+                  width={219}
+                  height={219}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+
+              <div className="flex-1 w-full">
+                <DisplayH4 className="text-neutral-1000">{accommodationName}</DisplayH4>
+                <div className="mt-4 flex flex-col gap-1">
+                  <div className="flex">
+                    <BodySmall className="text-neutral-600">요청 일시: </BodySmall>
+                    <BodySmall className="text-neutral-800 ml-1">
+                      {formatDateTime(requestedDatetime)}
+                    </BodySmall>
+                  </div>
+                  <div className="flex">
+                    <BodySmall className="text-neutral-600">청소 시작 시각: </BodySmall>
+                    <BodySmall className="text-neutral-800 ml-1">
+                      {formatDateTime(cleaningStartDateTime)}
+                    </BodySmall>
+                  </div>
+                  <div className="flex">
+                    <BodySmall className="text-neutral-600">
+                      청소 완료 날짜 및 희망 시각:{' '}
+                    </BodySmall>
+                    <BodySmall className="text-neutral-800 ml-1">
+                      {formatDateTime(completedAt)}
+                    </BodySmall>
+                  </div>
+                  <div className="flex">
+                    <BodySmall className="text-neutral-600">선택 옵션: </BodySmall>
+                    <BodySmall className="text-neutral-800 ml-1">{selectedOption}</BodySmall>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 청소 시작 전/후 업로드 사진 - 좌우 배치 */}
+          <div className="flex flex-col md:flex-row gap-6">
+            {/* 청소 시작 전 업로드 사진 */}
+            <div className="flex-1 space-y-4 min-w-0">
+              <TitleH4 className="text-neutral-1000">청소 시작 전 업로드 사진</TitleH4>
+              {beforeCleaningPhotos && beforeCleaningPhotos.length > 0 ? (
+                <div className="flex gap-4 overflow-x-auto scrollbar-hide w-full">
+                  {beforeCleaningPhotos.map((photo, index) => (
+                    <div
+                      key={index}
+                      className="flex-shrink-0 w-[112px] h-[112px] rounded-[20px] overflow-hidden bg-neutral-200"
+                    >
+                      <Image
+                        src={photo}
+                        alt={`청소 시작 전 사진 ${index + 1}`}
+                        width={112}
+                        height={112}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="h-[112px]" />
+              )}
+            </div>
+
+            {/* 청소 완료 후 업로드 사진 */}
+            <div className="flex-1 space-y-4 min-w-0">
+              <TitleH4 className="text-neutral-1000">청소 완료 후 업로드 사진</TitleH4>
+              {afterCleaningPhotos && afterCleaningPhotos.length > 0 ? (
+                <div className="flex gap-4 overflow-x-auto scrollbar-hide w-full">
+                  {afterCleaningPhotos.map((photo, index) => (
+                    <div
+                      key={index}
+                      className="flex-shrink-0 w-[112px] h-[112px] rounded-[20px] overflow-hidden bg-neutral-200"
+                    >
+                      <Image
+                        src={photo}
+                        alt={`청소 완료 후 사진 ${index + 1}`}
+                        width={112}
+                        height={112}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="h-[112px]" />
+              )}
+            </div>
+          </div>
+
+          {/* 작업 중 특이사항 및 증빙 사진 - 좌우 배치 */}
+          <div className="flex flex-col md:flex-row gap-6">
+            {/* 작업 중 특이사항 */}
+            <div className="flex-1 space-y-4 min-w-0">
+              <TitleH4 className="text-neutral-1000">작업 중 특이사항</TitleH4>
+              {specialNotes ? (
+                <TitleDefault className="text-neutral-800 whitespace-pre-wrap">
+                  {specialNotes}
+                </TitleDefault>
+              ) : (
+                <div className="h-[60px]" />
+              )}
+            </div>
+
+            {/* 특이사항 증빙 사진 */}
+            <div className="flex-1 space-y-4 min-w-0">
+              <TitleH4 className="text-neutral-1000">특이사항 증빙 사진</TitleH4>
+              {specialNotesPhotos && specialNotesPhotos.length > 0 ? (
+                <div className="flex gap-4 overflow-x-auto scrollbar-hide w-full">
+                  {specialNotesPhotos.map((photo, index) => (
+                    <div
+                      key={index}
+                      className="flex-shrink-0 w-[112px] h-[112px] rounded-[20px] overflow-hidden bg-neutral-200"
+                    >
+                      <Image
+                        src={photo}
+                        alt={`특이사항 증빙 사진 ${index + 1}`}
+                        width={112}
+                        height={112}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="h-[112px]" />
+              )}
+            </div>
+          </div>
+
+          {/* 결제 예상 금액 */}
+          <div className="space-y-4">
+            <TitleH4 className="text-neutral-1000">결제 예상 금액</TitleH4>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <BodyDefault className="text-neutral-600">기본 요금</BodyDefault>
+                <TitleDefault className="text-neutral-800">
+                  {new Intl.NumberFormat('ko-KR').format(baseFee)} 원
+                </TitleDefault>
+              </div>
+              <div className="flex justify-between items-center">
+                <BodyDefault className="text-neutral-600">
+                  플랫폼 수수료 ({platformFeeRate}%)
+                </BodyDefault>
+                <TitleDefault className="text-neutral-800">
+                  {new Intl.NumberFormat('ko-KR').format(platformFee)} 원
+                </TitleDefault>
+              </div>
+              <div className="border-t border-neutral-300 pt-2">
+                <div className="flex justify-between items-center">
+                  <BodyDefault className="text-neutral-1000">결제 예정 금액</BodyDefault>
+                  <TitleH4 className="text-neutral-1000">
+                    {new Intl.NumberFormat('ko-KR').format(baseFee + platformFee)}원
+                  </TitleH4>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 액션 버튼 */}
+          <div className="pt-4 flex flex-col md:flex-row gap-4 md:justify-end">
+            <div className="w-full md:w-[151px]">
+              <Button onClick={onRequestRework} variant="secondary" className="h-[46px] w-full">
+                재작업 요청하기
+              </Button>
+            </div>
+            <div className="w-full md:w-[151px]">
+              <Button onClick={onApprove} active className="h-[46px] w-full">
+                승인하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/organisms/InspectionWaitingListSection.tsx
+++ b/src/app/_components/organisms/InspectionWaitingListSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { DisplayDefault, DisplayH3, TitleH4 } from '../atoms/Typography';
 import CleaningRequestCard from '../molecules/card/CleaningRequestCard';
@@ -44,6 +45,7 @@ interface InspectionWaitingListSectionProps {
 }
 
 export default function InspectionWaitingListSection({ data }: InspectionWaitingListSectionProps) {
+  const router = useRouter();
   const [tab, setTab] = useState<InspectionTab>('request');
 
   // 탭에 따른 데이터 필터링
@@ -99,7 +101,7 @@ export default function InspectionWaitingListSection({ data }: InspectionWaiting
                 tab === 'request' && item.elapsedTime ? item.elapsedTime.formatted : undefined
               }
               onInspect={() => {
-                console.log('청소 상태 검수:', item.inspectionId);
+                router.push(`/mypage/inspection/detail/${item.inspectionId}`);
               }}
             />
           ))

--- a/src/app/mypage/inspection/detail/[id]/page.tsx
+++ b/src/app/mypage/inspection/detail/[id]/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import InspectionDetailSection from '@/app/_components/organisms/InspectionDetailSection';
+import RoomMainTemplate from '@/app/_components/templates/RoomMainTemplate';
+import { CLEANING_TYPE_LABELS } from '@/constants/business.constants';
+
+export default function InspectionDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const inspectionId = params.id as string;
+
+  // TODO: 실제 API 호출로 대체
+  // 현재는 목업 데이터 사용
+  const mockData = {
+    inspectionId: inspectionId || '01HQXYZ123',
+    accommodationName: '외대 앞 에어비앤비 자동 청소',
+    accommodationImageUrl: '/img/sample-room.jpg',
+    requestedDatetime: '2025-10-31T18:29:00.000Z',
+    cleaningStartDateTime: '2025-10-31T18:29:00.000Z',
+    completedAt: '2025-11-03T18:00:00.000Z',
+    options: 'BASIC' as const,
+    elapsedTime: '8시간 30분',
+    beforeCleaningPhotos: [
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+    ],
+    afterCleaningPhotos: [
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+    ],
+    specialNotes: '러그에 얼룩이 묻어있었습니다. 해당 부분 인지하면 좋을 것 같습니다.',
+    specialNotesPhotos: [
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+      '/img/sample-room.jpg',
+    ],
+    baseFee: 50000,
+    platformFee: 7500,
+    platformFeeRate: 15,
+  };
+
+  const handleApprove = () => {
+    // TODO: 승인 API 호출
+    console.log('승인하기:', inspectionId);
+    // 승인 후 검수 대기 목록으로 이동
+    router.push('/mypage/inspection');
+  };
+
+  const handleRequestRework = () => {
+    // TODO: 재작업 요청 API 호출
+    console.log('재작업 요청하기:', inspectionId);
+    // 재작업 요청 후 검수 대기 목록으로 이동
+    router.push('/mypage/inspection');
+  };
+
+  return (
+    <RoomMainTemplate>
+      <InspectionDetailSection
+        accommodationName={mockData.accommodationName}
+        accommodationImageUrl={mockData.accommodationImageUrl}
+        elapsedTime={mockData.elapsedTime}
+        requestedDatetime={mockData.requestedDatetime}
+        cleaningStartDateTime={mockData.cleaningStartDateTime}
+        completedAt={mockData.completedAt}
+        selectedOption={CLEANING_TYPE_LABELS[mockData.options] || mockData.options}
+        beforeCleaningPhotos={mockData.beforeCleaningPhotos}
+        afterCleaningPhotos={mockData.afterCleaningPhotos}
+        specialNotes={mockData.specialNotes}
+        specialNotesPhotos={mockData.specialNotesPhotos}
+        baseFee={mockData.baseFee}
+        platformFee={mockData.platformFee}
+        platformFeeRate={mockData.platformFeeRate}
+        onApprove={handleApprove}
+        onRequestRework={handleRequestRework}
+      />
+    </RoomMainTemplate>
+  );
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #55 
## 📝 작업 내용

> 청소 상태 검수 ui 구현 했습니다.
1. **청소 상태 검수 상세 페이지 생성**
   - `/mypage/inspection/detail/[id]` 동적 라우트 페이지 추가
   - `InspectionDetailSection` 컴포넌트 생성

2. **검수 상세 정보 표시**
   - 숙소 이미지 및 기본 정보 (제목, 요청 일시, 청소 시작/완료 시각, 선택 옵션)
   - 청소 완료 후 경과 시간 표시 (우측 상단)
   - 청소 시작 전/후 업로드 사진 갤러리 (각 섹션별 좌우 스크롤)
   - 작업 중 특이사항 및 증빙 사진
   - 결제 예상 금액 정보 (기본 요금, 플랫폼 수수료, 결제 예정 금액)

3. **액션 기능**
   - 승인하기 버튼 (검수 승인 후 검수 대기 목록으로 이동)
   - 재작업 요청하기 버튼 (재작업 요청 후 검수 대기 목록으로 이동)

4. **라우팅 연결**
   - 검수 대기 목록(`InspectionWaitingListSection`)에서 "청소 상태 검수" 버튼 클릭 시 검수 상세 페이지로 이동

### 📸 스크린샷 (선택)
<img width="3420" height="1890" alt="image" src="https://github.com/user-attachments/assets/b7967cef-cdf6-4d18-902d-11398a1027ab" />
<img width="778" height="1690" alt="image" src="https://github.com/user-attachments/assets/6454db10-575c-4e3f-a9f1-d37c713ef146" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
